### PR TITLE
added null pointer check to DeInit

### DIFF
--- a/src/GMECodec.cpp
+++ b/src/GMECodec.cpp
@@ -179,6 +179,9 @@ int64_t Seek(void* context, int64_t time)
 
 bool DeInit(void* context)
 {
+  if(!context)
+    return true;
+
   GMEContext* gme = (GMEContext*)context;
   gme_delete(gme->gme);
   delete gme;


### PR DESCRIPTION
The GME addon has never worked for me on Kodi 17.x. Browsing to a directory of game music files causes Kodi to crash without any messages or debug info. My kernel log shows a segfault which I traced to the DeInit function in GMECodec.cpp. I found that inserting a null check avoids the crash and allows the plugin to function.

However, I don't know anything about Kodi's innards or the interface. For all I know, I've blindly put a band-aid on a larger problem and kicked it up the road. Either way, this works for my purposes, and I wanted to bring the situation to your attention.